### PR TITLE
Add exclude window

### DIFF
--- a/pkg/filter/finalizer.go
+++ b/pkg/filter/finalizer.go
@@ -33,19 +33,6 @@ func HasFinalizer(obj runtime.Object) runtime.Object {
 	return obj
 }
 
-func IsDeleted(obj runtime.Object) runtime.Object {
-	m, err := meta.Accessor(obj)
-	if err != nil {
-		return nil
-	}
-
-	if m.GetDeletionTimestamp() == nil {
-		return nil
-	}
-
-	return obj
-}
-
 func IsDeletedOutsideWindow(window time.Duration) func(obj runtime.Object) runtime.Object {
 	return func(obj runtime.Object) runtime.Object {
 		m, err := meta.Accessor(obj)


### PR DESCRIPTION
In order to use this library in automation it could be useful to exclude objects that have been deleted within a certain window. For instance if the longest time I can expect clean up functions to take is 4 hours, then I only want to list objects that have a deleted time older than 4 hours from now.

* adds new `ExcludeSinceWindow` flag which accepts Time.Duration
* `IsDeleted()` takes an excludes window