### PR TITLE
Bump sys module to fix darwin_arm64 build errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.3
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e
 	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8
 )

--- a/go.sum
+++ b/go.sum
@@ -552,6 +552,8 @@ golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191002063906-3421d5a6bb1c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e h1:NHvCuwuS43lGnYhten69ZWqi2QOj/CiDNcKbVqwVoew=
+golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This currently fails to build on Apple Silicon-based Macs with an error along the lines of the following:

```
/Users/nick/src/golang/pkg/mod/golang.org/x/sys@v0.0.0-20191022100944-742c48ecaeb7/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
/Users/nick/src/golang/pkg/mod/golang.org/x/sys@v0.0.0-20191022100944-742c48ecaeb7/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
/Users/nick/src/golang/pkg/mod/golang.org/x/sys@v0.0.0-20191022100944-742c48ecaeb7/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```

Bumping the sys module fixes the issue and builds successfully.